### PR TITLE
Base 64 Encoding Patch

### DIFF
--- a/Commands/Encode Base 64 Line : Selection.plist
+++ b/Commands/Encode Base 64 Line : Selection.plist
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>${TM_RUBY:-ruby} -e 'print STDIN.read.to_a.pack("m*")'</string>
+	<string>${TM_RUBY:-ruby} -e 'print [STDIN.read].pack("m*")'</string>
 	<key>fallbackInput</key>
 	<string>line</string>
 	<key>input</key>


### PR DESCRIPTION
The Mail bundle's Encode Base 64 Line/Selection command does not propertly
handle multiline input. This may be an issue with the underlying Ruby pack
implementation, which only appears to work on the first string in the array,
and calling `#to_a` on a string splits it at the \n character. (I've tried
multiple Ruby versions on different OSes and all all fail on multiline input
when using `String#to_a`).

Input:

```
Lorem ipsum dolor sit amet, consectetur adipiscing elit.
Quisque gravida nulla non ante venenatis dictum. Cum
sociis natoque penatibus et magnis dis parturient montes,
nascetur ridiculus mus. Curabitur id nibh eu tortor porta
tincidunt nec elementum metus.
```

Expected Result:

```
TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBp
c2NpbmcgZWxpdC4KUXVpc3F1ZSBncmF2aWRhIG51bGxhIG5vbiBhbnRlIHZl
bmVuYXRpcyBkaWN0dW0uIEN1bQpzb2NpaXMgbmF0b3F1ZSBwZW5hdGlidXMg
ZXQgbWFnbmlzIGRpcyBwYXJ0dXJpZW50IG1vbnRlcywKbmFzY2V0dXIgcmlk
aWN1bHVzIG11cy4gQ3VyYWJpdHVyIGlkIG5pYmggZXUgdG9ydG9yIHBvcnRh
CnRpbmNpZHVudCBuZWMgZWxlbWVudHVtIG1ldHVzLg==
```

Actual Result:

```
TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBp
c2NpbmcgZWxpdC4K
```

Result After Patch:

```
TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBp
c2NpbmcgZWxpdC4KUXVpc3F1ZSBncmF2aWRhIG51bGxhIG5vbiBhbnRlIHZl
bmVuYXRpcyBkaWN0dW0uIEN1bQpzb2NpaXMgbmF0b3F1ZSBwZW5hdGlidXMg
ZXQgbWFnbmlzIGRpcyBwYXJ0dXJpZW50IG1vbnRlcywKbmFzY2V0dXIgcmlk
aWN1bHVzIG11cy4gQ3VyYWJpdHVyIGlkIG5pYmggZXUgdG9ydG9yIHBvcnRh
CnRpbmNpZHVudCBuZWMgZWxlbWVudHVtIG1ldHVzLg==
```

Wrapping the return string in an array instead of using the result of `#to_a`
works as expected.

This has also been posted to [textmate-dev](http://lists.macromates.com/textmate-dev/2010-November/014440.html).
