### PR TITLE
Update e-mail regex to comply more to RFC 5322

### DIFF
--- a/Syntaxes/Email Address.tmLanguage
+++ b/Syntaxes/Email Address.tmLanguage
@@ -12,7 +12,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>(?i)\b([A-Z][A-Z0-9._%+-]+)@([A-Z0-9.\-]+)\.([A-Z]{2,4})\b</string>
+			<string>(?i)\b([A-Z0-9._%+-]+)@([A-Z0-9.-]+)\.([A-Z]{2,})\b</string>
 			<key>name</key>
 			<string>markup.underline.link.email.hyperlink</string>
 		</dict>


### PR DESCRIPTION
The old regex was only recognizing mails starting with alphabetic characters. Also the tld can be longer than 4 elements - checking http://data.iana.org/TLD/tlds-alpha-by-domain.txt will provide some longer domains than 4 characters.